### PR TITLE
Big rename and clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 A utility package for reinforcement learning study of Hironaka's game of local resolution of singularities and its
 variation problems.
 
+# Quick start
+
+[This notebook](https://cocalc.com/share/public_paths/5db3252a0bcb8d068aad2ee53bf5a1ce85753ebf) provides a brief demonstration of key classes in this repo. It is highly recommended to take a look first if you are an example-oriented learner.
+
+# Contents
+
 For ML and RL specialists, the following two sections should give you an overview:
 
 - [Rule of the game](#rule-of-the-game)
@@ -17,15 +23,22 @@ For math-oriented viewers or ML experts who are intrigued about the background s
 
 # Rule of the game
 
-There are two players. To separate the roles, we name them 'host' and 'agent'.
+## The definition of the game
 
-Game state: a set of integral points .......
+The original Hironaka game is a game consisting of 2 players. They operate in a non-symmetric fashion. To emphasize the difference, let us call player 1 the "host", player 2 the "agent". For every turn the game has a `state`, the host makes a move, and the agents makes a move. Their moves change the `state` and the game goes into the next turn. 
 
-Host: ......
+A `state` is represented by a set of points $S\in\mathbb Z^n$ who are the vertices of the Newton polytope $S$ itself.
 
-Agent: ......
+Every turn, 
 
-......
+- The host chooses a subset $I\subset \{1,2,\cdots, n\}$ such that $|I|\geq 2$.
+- The agent chooses a number $i\in I$.
+
+$i, I$ together changes the `state` $S$ to the next according to the following linear change of variables:
+$$x_j \mapsto \begin{cases}x_j, &\qquad\text{if } i\neq j \\ \sum\limits_{k\in I} x_k, &\qquad\text{if }i=j \end{cases},$$
+for points $(x_1,\cdots,x_n)\in \mathbb Z^n$. We subsequently apply Newton polytope to the transformed points and only keep the vertices.
+
+A `state` is terminal if it consists of one single point. In this case, the game will not continue and the host wins. As a result, the host wants to reduce the number of $S$ as quickly as possible, but the agent wants to keep the number of $S$ for as long as possible.
 
 # The structure of the repo
 

--- a/hironaka/Points.py
+++ b/hironaka/Points.py
@@ -1,0 +1,29 @@
+from hironaka.core import ListPoints
+
+
+class PointsWrapper:
+    """
+        A simple wrapper allowing for simple usage of basic functions of `ListPoints`
+    """
+    points_config = {
+        'use_precise_newton_polytope': True,
+        'value_threshold': 1e8
+    }
+
+    def __init__(self, points, distinguished_point=None):
+        distinguished_point = [distinguished_point] if distinguished_point is not None else None
+        self.points = ListPoints([points], distinguished_points = distinguished_point, **self.points_config)
+
+        self.points.get_newton_polytope()
+        self.track_dist_point = distinguished_point is not None
+
+    def step(self, host_coordinates, agent_coordinate) -> bool:
+        if self.points.ended or (self.track_dist_point and self.points.distinguished_points[0] is None):
+            return False
+        self.points.shift([host_coordinates], [agent_coordinate])
+        self.points.get_newton_polytope()
+        return True
+
+    @property
+    def has_ended(self):
+        return self.points.ended

--- a/hironaka/README.md
+++ b/hironaka/README.md
@@ -12,5 +12,4 @@ Submodules:
 
 Python scripts and non-essential functions:
 
- - [.train/](../train)
  - [.util/](util)

--- a/hironaka/agent.py
+++ b/hironaka/agent.py
@@ -3,7 +3,7 @@ import logging
 from typing import List, Final
 
 import numpy as np
-from hironaka.core import Points
+from hironaka.core import ListPoints
 from hironaka.policy.Policy import Policy
 
 
@@ -31,7 +31,7 @@ class Agent(abc.ABC):
             if not hasattr(self, s) or getattr(self, s) is None:
                 raise NotImplementedError(f"Please specify {s} for the subclass.")
 
-    def move(self, points: Points, coords, weights=None, inplace=True):
+    def move(self, points: ListPoints, coords, weights=None, inplace=True):
         if self.USE_WEIGHTS and weights is None:
             raise Exception("Please specify weights in the parameters.")
         if not self.USE_WEIGHTS and weights is not None:

--- a/hironaka/core/ListPoints.py
+++ b/hironaka/core/ListPoints.py
@@ -7,7 +7,7 @@ from hironaka.src import shift_lst, get_newton_polytope_lst, get_shape, scale_po
     get_newton_polytope_approx_lst
 
 
-class Points(PointsBase):
+class ListPoints(PointsBase):
     """
         When dealing with small batches, small dimension and small point numbers, list is much better than numpy.
     """

--- a/hironaka/core/NumpyPoints.py
+++ b/hironaka/core/NumpyPoints.py
@@ -1,7 +1,7 @@
 from .PointsBase import PointsBase
 
 
-class PointsNumpy(PointsBase):  # INCOMPLETE
+class NumpyPoints(PointsBase):  # INCOMPLETE
     """
         Storing points using numpy arrays.
     """

--- a/hironaka/core/README.md
+++ b/hironaka/core/README.md
@@ -4,9 +4,9 @@ This is the core functionality whose classes
  - perform transformations (Newton polytope, shift, rescale, etc.),
  - provide features, states, etc.
 
-The base class is `PointsBase`, and the subclasses are currently `Points` and `PointsTensor`. 
+The base class is `PointsBase`, and the subclasses are currently `ListPoints` and `TensorPoints`. 
 
-`PointsNumpy` is currently unnecessary and the implementation is postponed.
+`NumpyPoints` is currently unnecessary and the implementation is postponed.
 
 ## .PointsBase
 This interface is an abstraction of collection of points used in the Hironaka games and its variations.
@@ -17,7 +17,7 @@ A couple important notes:
  - Subclasses must define `subcls_config_keys, copied_attributes`.
    - `subcls_config_keys` defines the config keys that will be tracked and initialized when creating a copy object in `.copy()` method. In other words, they are configs that stay unchanged throughout space transformations.
    - `copied_attributes` defines the keys of the attributes that will be directly copied after initialization in `.copy()`. In other words, they may be changed during space transformations and is partially the information of the state (e.g., `.ended`).
- - Shape of points can be specified with config parameters `points_batch_size, dimension, max_number_points`. If they are not given, it will look over the point data and initialize `.batch_size, .dimension, .max_num_points` attributes.
+ - Shape of points can be specified with config parameters `points_batch_size, dimension, max_num_points`. If they are not given, it will look over the point data and initialize `.batch_size, .dimension, .max_num_points` attributes.
 
 Must implement: 
 ` 
@@ -37,7 +37,7 @@ get_features
 _get_max_num_points
 `
 
-## .Points
+## .ListPoints
 It stores the points in nested lists and perform list-based transformations. The nested lists do not have to be of uniform shape (not padded).
 For example:
 
@@ -56,9 +56,9 @@ For example:
 
 This is a batch of 2 separate sets of points. They are of different sizes.
 
-## .PointsTensor
+## .TensorPoints
 It performs everything using PyTorch tensors.
 
-Major differences between `PointsTensor` and `Points`
- - `PointsTensor.points` have a fixed shape. Removed points will be replaced by `padded_value` which must be a negative number.
- - In `Points.points`, the order of points may change during `get_newton_polytope()`. But for `PointsTensor.points`, the order will never change. When points are removed, we still maintain the original orders without moving surviving points next to each other. As a result, `distinguished_points` marks the distinguished point in each set of points, but is never changed under any operations.
+Major differences between `TensorPoints` and `ListPoints`
+ - `TensorPoints.points` have a fixed shape. Removed points will be replaced by `padded_value` which must be a negative number.
+ - In `ListPoints.points`, the order of points may change during `get_newton_polytope()`. But for `TensorPoints.points`, the order will never change. When points are removed, we still maintain the original orders without moving surviving points next to each other. As a result, `distinguished_points` marks the distinguished point in each set of points, but is never changed under any operations.

--- a/hironaka/core/TensorPoints.py
+++ b/hironaka/core/TensorPoints.py
@@ -8,7 +8,7 @@ from hironaka.src import get_batched_padded_array, rescale_torch
 from hironaka.src import shift_torch, get_newton_polytope_torch, reposition_torch
 
 
-class PointsTensor(PointsBase):
+class TensorPoints(PointsBase):
     subcls_config_keys = ['value_threshold', 'device_key', 'padding_value']
     copied_attributes = ['distinguished_points']
 

--- a/hironaka/core/__init__.py
+++ b/hironaka/core/__init__.py
@@ -1,3 +1,3 @@
-from .Points import *
-from .PointsTensor import *
+from .ListPoints import *
+from .TensorPoints import *
 

--- a/hironaka/game.py
+++ b/hironaka/game.py
@@ -2,7 +2,7 @@ import abc
 import logging
 from typing import Optional, Union
 
-from hironaka.core import Points
+from hironaka.core import ListPoints
 from hironaka.agent import Agent
 from hironaka.host import Host
 
@@ -66,7 +66,7 @@ class Game(abc.ABC):
 
 class GameHironaka(Game):
     def __init__(self,
-                 state: Union[Points, None],
+                 state: Union[ListPoints, None],
                  host: Host,
                  agent: Agent,
                  scale_observation: Optional[bool] = True,
@@ -119,7 +119,7 @@ class GameMorin(Game):
     after the shift"""
 
     def __init__(self,
-                 state: Union[Points, None],
+                 state: Union[ListPoints, None],
                  host: Host,
                  agent: Agent,
                  scale_observation: Optional[bool] = True,

--- a/hironaka/gym_env/HironakaBase.py
+++ b/hironaka/gym_env/HironakaBase.py
@@ -5,7 +5,7 @@ import gym
 import numpy as np
 from gym import spaces
 
-from hironaka.core import Points
+from hironaka.core import ListPoints
 from hironaka.src import get_padded_array, get_gym_version_in_float, generate_points
 
 ObsType = TypeVar("ObsType")
@@ -89,12 +89,12 @@ class HironakaBase(gym.Env, abc.ABC):
             super().reset(seed=seed)
 
         if points is None:
-            self._points = Points(
+            self._points = ListPoints(
                 [generate_points(self.max_number_points, **self.config_for_generate_points)],
                 value_threshold=self.value_threshold
             )
         else:
-            self._points = Points(points, **self.config_for_points)
+            self._points = ListPoints(points, **self.config_for_points)
 
         self._points.get_newton_polytope()
         if self.scale_observation:

--- a/hironaka/policy/README.md
+++ b/hironaka/policy/README.md
@@ -7,7 +7,7 @@ __init__
 predict
 `
 
-Note that `input_preprocess_for_host` and `input_preprocess_for_agent` are merely helper functions for input preprocessing of list-based observations (e.g., class `Points`).
+Note that `input_preprocess_for_host` and `input_preprocess_for_agent` are merely helper functions for input preprocessing of list-based observations (e.g., class `ListPoints`).
 Feel free to override them for different purposes.
 
 ## .NNPolicy

--- a/hironaka/util/search.py
+++ b/hironaka/util/search.py
@@ -2,11 +2,11 @@ from collections import deque, namedtuple
 
 import numpy as np
 
-from hironaka.core import Points
+from hironaka.core import ListPoints
 from hironaka.host import Host
 
 
-def search_depth(points: Points, host: Host, debug=False):
+def search_depth(points: ListPoints, host: Host, debug=False):
     """
         Given the host, return the maximal length of the game that an agent can achieve.
     """
@@ -52,7 +52,7 @@ def search_tree(points, tree, curr_node, host, max_size=100):
     return tree
 
 
-def search_tree_morin(points: Points, tree, curr_node, curr_weights, host, max_size=100):
+def search_tree_morin(points: ListPoints, tree, curr_node, curr_weights, host, max_size=100):
     """
         Perform a full tree search and store the full result in a Tree object.
     """

--- a/hironaka/validator/HironakaValidator.py
+++ b/hironaka/validator/HironakaValidator.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional, Dict, Any
 
-from hironaka.core import Points
+from hironaka.core import ListPoints
 from hironaka.game import GameHironaka
 from hironaka.src import generate_batch_points
 
@@ -57,7 +57,7 @@ class HironakaValidator(GameHironaka):
         return len_history
 
     def reset(self):
-        self.state = Points(generate_batch_points(**self.points_config), value_threshold=self.value_threshold)
+        self.state = ListPoints(generate_batch_points(**self.points_config), value_threshold=self.value_threshold)
         if self.scale_observation:
             self.state.rescale()
         self.stopped = False

--- a/test/testGame.py
+++ b/test/testGame.py
@@ -3,13 +3,13 @@ import unittest
 from hironaka.agent import RandomAgent, ChooseFirstAgent
 from hironaka.game import GameHironaka
 from hironaka.host import Zeillinger, WeakSpivakovsky, RandomHost
-from hironaka.core import Points
+from hironaka.core import ListPoints
 from hironaka.src import generate_points, generate_batch_points
 
 
 class TestGame(unittest.TestCase):
     def test_random_games(self):
-        points = Points(generate_points(5))
+        points = ListPoints(generate_points(5))
         agent = RandomAgent()
         host = RandomHost()
         game = GameHironaka(points, host, agent)
@@ -21,7 +21,7 @@ class TestGame(unittest.TestCase):
         game.print_history()
 
     def test_random_batch_games(self):
-        points = Points(generate_batch_points(5, batch_num=5))
+        points = ListPoints(generate_batch_points(5, batch_num=5))
         agent = RandomAgent()
         host = RandomHost()
         game = GameHironaka(points, host, agent)
@@ -33,13 +33,13 @@ class TestGame(unittest.TestCase):
         game.print_history()
 
     def test_agent_host_ignore_batch(self):
-        points = Points([[0, 1], [1, 0]])
+        points = ListPoints([[0, 1], [1, 0]])
         agent = ChooseFirstAgent(ignore_batch_dimension=True)
         assert agent.move(points, [0, 1], inplace=False) == 0
         agent.move(points, [0, 1])
         assert str(points.points) == "[[[1, 0]]]"
 
-        points = Points([[0, 1, 2], [2, 1, 0]])
+        points = ListPoints([[0, 1, 2], [2, 1, 0]])
         host = Zeillinger(ignore_batch_dimension=True)
         assert str(host.select_coord(points)) == "[0, 2]"
 

--- a/test/testGymEnv.py
+++ b/test/testGymEnv.py
@@ -4,7 +4,7 @@ import gym
 import numpy as np
 from gym.envs.registration import register
 
-from hironaka.core import Points
+from hironaka.core import ListPoints
 from hironaka.agent import RandomAgent
 from hironaka.host import Zeillinger, RandomHost
 
@@ -31,7 +31,7 @@ class TestEnv(unittest.TestCase):
         env.render()
         stopped = False
         while not stopped:
-            action = agent.move(Points(np.expand_dims(o.get('points'), axis=0)), [np.where(o.get('coords') == 1)[0]],
+            action = agent.move(ListPoints(np.expand_dims(o.get('points'), axis=0)), [np.where(o.get('coords') == 1)[0]],
                                 inplace=False)
             o, r, stopped, info = env.step(action[0])
             print(f"Reward: {r}")
@@ -49,7 +49,7 @@ class TestEnv(unittest.TestCase):
         env.render()
         stopped = False
         while not stopped:
-            action = host.select_coord(Points(np.expand_dims(o, axis=0)))[0]
+            action = host.select_coord(ListPoints(np.expand_dims(o, axis=0)))[0]
             action_input = np.zeros(dim)
             action_input[action] = 1
             o, r, stopped, info = env.step(action_input)

--- a/test/testPoints.py
+++ b/test/testPoints.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from hironaka.core import Points
+from hironaka.core import ListPoints
 from hironaka.src import make_nested_list, generate_points
 
 
@@ -10,20 +10,20 @@ class TestPoints(unittest.TestCase):
     def test_define_point(self):
         points = generate_points(5)
         print(points)
-        points = Points(points)
+        points = ListPoints(points)
         print(points)
 
     def test_operations(self):
         # host = Zeillinger()
-        points = Points(make_nested_list(
+        points = ListPoints(make_nested_list(
             [(7, 5, 3, 8), (8, 1, 8, 18), (8, 3, 17, 8),
              (11, 11, 1, 19), (11, 12, 18, 6), (16, 11, 5, 6)]
         ))
-        p2 = Points(make_nested_list(
+        p2 = ListPoints(make_nested_list(
             [(0, 1, 0, 1), (0, 2, 0, 0), (1, 0, 0, 1),
              (1, 0, 1, 0), (1, 1, 0, 0), (2, 0, 0, 0)]))
 
-        result = Points(make_nested_list(
+        result = ListPoints(make_nested_list(
             [[[7, 5, 11, 8],
               [8, 1, 26, 18],
               [8, 3, 25, 8],
@@ -39,11 +39,11 @@ class TestPoints(unittest.TestCase):
         # print(p2)
 
     def test_operations2(self):
-        p = Points(make_nested_list(
+        p = ListPoints(make_nested_list(
             [(7, 5, 3, 8), (8, 9, 8, 18), (8, 3, 17, 8),
              (11, 11, 1, 19), (11, 12, 18, 6), (16, 11, 5, 6)]
         ))
-        q = Points(make_nested_list(
+        q = ListPoints(make_nested_list(
             [(7, 5, 3, 8), (8, 9, 8, 18), (8, 3, 17, 8),
              (11, 11, 1, 19), (11, 12, 18, 6), (16, 11, 5, 6)]
         ))
@@ -58,7 +58,7 @@ class TestPoints(unittest.TestCase):
               [-1, -1, -1, -1]]]
         ))
         """
-        r2 = Points(make_nested_list(
+        r2 = ListPoints(make_nested_list(
             [[[16, 11, 5, 6], [11, 12, 18, 6], [11, 11, 1, 19], [8, 3, 17, 8], [7, 5, 3, 8]]]
         ))
         q.get_newton_polytope()
@@ -67,7 +67,7 @@ class TestPoints(unittest.TestCase):
         assert str(q) == str(r2)
 
     def test_features(self):
-        p = Points(make_nested_list(
+        p = ListPoints(make_nested_list(
             [(7, 5, 3, 8), (8, 9, 8, 18), (8, 3, 17, 8),
              (11, 11, 1, 19), (11, 12, 18, 6), (16, 11, 5, 6)]
         ))
@@ -77,7 +77,7 @@ class TestPoints(unittest.TestCase):
         assert str(p.get_sym_features()) == str(r)
 
     def test_get_batch(self):
-        p = Points(make_nested_list(
+        p = ListPoints(make_nested_list(
             [[(7, 5, 3, 8), (8, 9, 8, 18), (8, 3, 17, 8),
               (11, 11, 1, 19), (11, 12, 18, 6), (16, 11, 5, 6)],
              [(0, 1, 0, 1), (0, 2, 0, 0), (1, 0, 0, 1),
@@ -88,7 +88,7 @@ class TestPoints(unittest.TestCase):
         assert str(p.get_batch(1)) == str(r)
 
     def test_numpy_input_without_use_np(self):
-        p = Points(np.array(
+        p = ListPoints(np.array(
             [[[7, 5, 11, 8],
               [8, 1, 26, 18],
               [8, 3, 25, 8],
@@ -105,7 +105,7 @@ class TestPoints(unittest.TestCase):
         assert str(p.points) == str(r)
 
     def test_scale(self):
-        points = Points(make_nested_list(
+        points = ListPoints(make_nested_list(
             [(7, 5, 3, 8), (8, 1, 8, 18), (8, 3, 17, 8),
              (11, 11, 1, 19), (11, 12, 18, 6), (16, 11, 5, 6)]
         ))
@@ -123,24 +123,24 @@ class TestPoints(unittest.TestCase):
         # print(p2)
 
     def test_value_threshold(self):
-        points = Points([[[5e7, 5e7 + 1, 1e7], [1, 1, 2]]], value_threshold=int(1e8))
+        points = ListPoints([[[5e7, 5e7 + 1, 1e7], [1, 1, 2]]], value_threshold=int(1e8))
         assert not points.exceed_threshold()
         points.shift([[0, 1]], [0])
         assert points.exceed_threshold()
 
     def test_reposition(self):
-        points = Points(make_nested_list(
+        points = ListPoints(make_nested_list(
             [(7, 5, 3, 8), (8, 1, 8, 18), (8, 3, 17, 8),
              (11, 11, 1, 19), (11, 12, 18, 6), (16, 11, 5, 6)]
         ))
-        r = Points([[[0, 4, 2, 2], [1, 0, 7, 12], [1, 2, 16, 2], [4, 10, 0, 13], [4, 11, 17, 0], [9, 10, 4, 0]]])
+        r = ListPoints([[[0, 4, 2, 2], [1, 0, 7, 12], [1, 2, 16, 2], [4, 10, 0, 13], [4, 11, 17, 0], [9, 10, 4, 0]]])
         points.reposition()
         a = points.reposition(inplace=False)
         assert str(points) == str(r)
         assert str(points) == str(a)
 
     def test_distinguished_elements(self):
-        points = Points(make_nested_list(
+        points = ListPoints(make_nested_list(
             [(7, 5, 3, 8), (8, 1, 8, 18), (8, 3, 17, 8),
              (11, 11, 1, 19), (11, 12, 18, 6), (16, 11, 5, 6)]
         ), distinguished_points=[2])
@@ -162,7 +162,7 @@ class TestPoints(unittest.TestCase):
         assert d_ind is None
 
     def test_true_newton_polytope(self):
-        points = Points(make_nested_list(
+        points = ListPoints(make_nested_list(
             [(7, 5, 3, 8), (8, 1, 8, 18), (8, 3, 17, 8),
              (11, 11, 1, 19), (11, 12, 18, 6), (16, 11, 5, 6)]
         ), use_precise_newton_polytope=True)
@@ -173,7 +173,7 @@ class TestPoints(unittest.TestCase):
         points.get_newton_polytope()
         assert str(points.points) == str(r)
 
-        points = Points([[[0.,1.],[1.,0.],[0.9,0.9]]], use_precise_newton_polytope=True)
+        points = ListPoints([[[0., 1.], [1., 0.], [0.9, 0.9]]], use_precise_newton_polytope=True)
 
         r = [[[1.0, 0.0], [0.0, 1.0]]]
 

--- a/test/testPolicy.py
+++ b/test/testPolicy.py
@@ -2,7 +2,7 @@ import unittest
 
 from torch import nn
 
-from hironaka.core import Points
+from hironaka.core import ListPoints
 from hironaka.game import GameHironaka
 from hironaka.policy.NNPolicy import NNPolicy
 from hironaka.agent import PolicyAgent
@@ -56,7 +56,7 @@ class TestUtil(unittest.TestCase):
         agent = PolicyAgent(pl_a)
         host = PolicyHost(pl_h)
 
-        game = GameHironaka(Points(generate_batch_points(11, dimension=4)), host, agent)
+        game = GameHironaka(ListPoints(generate_batch_points(11, dimension=4)), host, agent)
 
         print(game.state)
         for _ in range(10):

--- a/test/testSearch.py
+++ b/test/testSearch.py
@@ -2,7 +2,7 @@ import unittest
 
 from treelib import Tree
 
-from hironaka.core import Points
+from hironaka.core import ListPoints
 from hironaka.host import Zeillinger
 from hironaka.src import make_nested_list
 from hironaka.util import search_depth, search_tree
@@ -10,7 +10,7 @@ from hironaka.util import search_depth, search_tree
 
 class TestSearch(unittest.TestCase):
     def test_search_depth(self):
-        points = Points(make_nested_list(
+        points = ListPoints(make_nested_list(
             [[(7, 5, 3, 8), (8, 1, 8, 18), (8, 3, 17, 8),
               (11, 11, 1, 19), (11, 12, 18, 6), (16, 11, 5, 6)]]
         ))
@@ -23,21 +23,21 @@ class TestSearch(unittest.TestCase):
         assert r == 5552
 
     def test_search_depth_small(self):
-        points = Points(make_nested_list([(0, 1, 0, 1), (0, 2, 0, 0), (1, 0, 0, 1),
-                                          (1, 0, 1, 0), (1, 1, 0, 0), (2, 0, 0, 0)]))
+        points = ListPoints(make_nested_list([(0, 1, 0, 1), (0, 2, 0, 0), (1, 0, 0, 1),
+                                              (1, 0, 1, 0), (1, 1, 0, 0), (2, 0, 0, 0)]))
         r = search_depth(points, Zeillinger())
         print(r)
         assert r == 6
 
     def test_search_special_char_vec(self):
-        points = Points([[[3, 5, 8], [5, 2, 6], [1, 3, 6], [3, 5, 3], [7, 3, 3], [1, 6, 3], [1, 0, 6], [5, 1, 6],
-                          [7, 3, 0], [6, 7, 7]]])
+        points = ListPoints([[[3, 5, 8], [5, 2, 6], [1, 3, 6], [3, 5, 3], [7, 3, 3], [1, 6, 3], [1, 0, 6], [5, 1, 6],
+                              [7, 3, 0], [6, 7, 7]]])
         r = search_depth(points, Zeillinger())
         print(r)
 
     def test_search(self):
         host = Zeillinger()
-        points = Points(make_nested_list([(0, 0, 4), (5, 0, 1), (1, 5, 1), (0, 25, 0)]))
+        points = ListPoints(make_nested_list([(0, 0, 4), (5, 0, 1), (1, 5, 1), (0, 25, 0)]))
 
         tree = Tree()
         tree.create_node(0, 0, data=points)

--- a/test/testThom.py
+++ b/test/testThom.py
@@ -2,7 +2,7 @@ import unittest
 
 from treelib import Tree
 
-from hironaka.core import Points
+from hironaka.core import ListPoints
 from hironaka.agent import AgentMorin
 from hironaka.game import GameMorin
 from hironaka.host import ZeillingerLex, WeakSpivakovsky
@@ -17,7 +17,7 @@ class TestThom(unittest.TestCase):
         agent = AgentMorin()
         points = thom_points_homogeneous(N)
         opoints = thom_points(N)
-        game = GameMorin(Points([points], distinguished_points=[len(points) - 1]), host, agent)
+        game = GameMorin(ListPoints([points], distinguished_points=[len(points) - 1]), host, agent)
 
         ro = [(4, 1, 0, 1, 0, 0, 0), (4, 1, 0, 0, 0, 1, 0), (4, 1, 0, 0, 0, 0, 1), (4, 0, 2, 0, 0, 0, 0),
               (4, 0, 1, 0, 1, 0, 0), (4, 0, 0, 0, 2, 0, 0), (3, 2, 1, 0, 0, 0, 0), (3, 2, 0, 0, 1, 0, 0),
@@ -46,7 +46,7 @@ class TestThom(unittest.TestCase):
         points = thom_points_homogeneous(4)
         print(f"Points: {points}")
         dimension = len(points[0])
-        initial_points = Points([points], distinguished_points=[len(points) - 1])
+        initial_points = ListPoints([points], distinguished_points=[len(points) - 1])
 
         tree = Tree()
         tree.create_node(0, 0, data=initial_points)

--- a/test/testTorchPoints.py
+++ b/test/testTorchPoints.py
@@ -2,7 +2,7 @@ import unittest
 
 import torch
 
-from hironaka.core import PointsTensor
+from hironaka.core import TensorPoints
 from hironaka.src import get_newton_polytope_torch, shift_torch, reposition_torch
 
 
@@ -72,7 +72,7 @@ class testTorchPoints(unittest.TestCase):
             ]
         )
 
-        pts = PointsTensor(p)
+        pts = TensorPoints(p)
 
         pts.get_newton_polytope()
         assert str(pts) == str(self.r)

--- a/test/testZeillinger.py
+++ b/test/testZeillinger.py
@@ -1,6 +1,6 @@
 import unittest
 
-from hironaka.core import Points
+from hironaka.core import ListPoints
 from hironaka.host import Zeillinger
 from hironaka.src import make_nested_list
 
@@ -8,12 +8,12 @@ from hironaka.src import make_nested_list
 class TestZeillinger(unittest.TestCase):
     def test_select_coord(self):
         host = Zeillinger()
-        points = Points(make_nested_list([(0, 0, 4), (5, 0, 1), (1, 5, 1), (0, 25, 0)]))
+        points = ListPoints(make_nested_list([(0, 0, 4), (5, 0, 1), (1, 5, 1), (0, 25, 0)]))
 
         assert tuple(host.select_coord(points, debug=True)[0]) == (0, 2)
 
     def test_char_vector(self):
         host = Zeillinger()
-        points = Points(make_nested_list([(0, 0, 4), (5, 0, 1), (1, 5, 1), (0, 25, 0)]))
+        points = ListPoints(make_nested_list([(0, 0, 4), (5, 0, 1), (1, 5, 1), (0, 25, 0)]))
 
         assert host.get_char_vector((5, 0, -3)) == (8, 2)


### PR DESCRIPTION
Changing names:
`core.Points` -> `core.ListPoints`
`core.PointsTensor` -> `core.TensorPoints`
Added new class:
`.Points`
The purpose of this new class is to serve as a simplified interface (in particular, ignoring the batch dimension, simpler config, smaller amount of attributes).